### PR TITLE
Allow transactionInCallback() to have a return value

### DIFF
--- a/src/database/Database.php
+++ b/src/database/Database.php
@@ -154,17 +154,16 @@ class Database
         }
     }
 
-    public function transactionInCallback(callable $callback): void
+    public function transactionInCallback(callable $callback): mixed
     {
         $this->beginTransaction();
 
         try {
-            $callback($this);
-
+            $result = $callback($this);
             $this->commitTransaction();
+            return $result;
         } catch (Throwable $exception) {
             $this->rollbackTransaction();
-
             throw $exception;
         }
     }


### PR DESCRIPTION
From my experience I learned that sometimes a transaction has to return some value, and the transactionInCallback(), being a very handy shortcut, didn't allow that.